### PR TITLE
Update popup when the plugin got updated

### DIFF
--- a/.github/workflows/draft-beta-release.yaml
+++ b/.github/workflows/draft-beta-release.yaml
@@ -1,0 +1,97 @@
+# ======================================================================================================================================================
+# Custom GitHub Action to draft a pre-release
+#
+# A GitHub draft pre-release is automatically created when the plugin's
+# `manifest-beta.json` is updated on the `release` branch.
+#
+# Based on :
+#   - [Obsidian developers docs](https://docs.obsidian.md/Plugins/Releasing/Release+your+plugin+with+GitHub+Actions)
+#   - [BRAT docs for developers](https://tfthacker.com/brat-developers)
+#   - [Excellent tutorial for multiline strings in GitHub Actions by Thomas Stringer](https://trstringer.com/github-actions-multiline-strings/)
+# ======================================================================================================================================================
+name: "Create a draft Beta pre-release"
+
+on:
+    # The workflow can be run manually
+    workflow_dispatch:
+    # The workflow is also triggered automatically when a push
+    # happens where the plugin's `manifest-beta.json` is modified
+    push:
+        branches:
+            - release
+        paths:
+            - 'manifest-beta.json'
+
+jobs:
+  create-draft-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Build plugin
+        run: |
+          npm install
+          npm run build
+
+      # To easily read JSON files and extract the version from the manifest
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.1.0
+
+      - name: Extract tag from manifest
+        # Extract the tag to use from the beta manifest file
+        run: |
+          tag=$(jq -r '.version' manifest-beta.json)
+          echo "Extracted tag: $tag"
+          echo "TAG=$tag" >> $GITHUB_ENV
+
+      # Prepare a release notes template
+      - name: Prepare generic release notes
+        run: |
+          notes=$(cat <<EOF
+          Open \`.ipynb\` files, edit them and run them directly inside of Obsidian without the need to open a terminal or a browser.
+
+          Obsidian Jupyter is a plugin for [Obsidian](https://obsidian.md) that offers [Jupyter](https://jupyter.org/) Notebook and Lab integration directly into Obsidian.
+
+          ## How to install
+
+          Interested? Please follow the instructions of the [documentation](https://jupyter.mael.im) and let me hear your feedback, it enables me to keep improve the plugin. Thank you in advance !
+
+          ## Change Log
+
+          ### Features
+
+          ### Bug fixes
+
+          ### Documentation
+
+          ### Logistic
+
+          ### Development
+          EOF
+          )
+          # Thank you Thomas Stringer for this : https://trstringer.com/github-actions-multiline-strings/
+          echo "NOTES<<EOF" >> $GITHUB_ENV
+          echo "$notes" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create draft release
+        env:
+          # Extract the variables set previously from the environment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ env.TAG }}
+          NOTES: ${{ env.NOTES }}
+        # Create a draft release with GitHub CLI
+        run: |
+          gh release create "$TAG" \
+            --title="Obsidian Jupyter v$TAG" \
+            --draft \
+            --prerelease \
+            --notes "$NOTES" \
+            --generate-notes \
+            main.js manifest-beta.json styles.css

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -1,0 +1,95 @@
+# ======================================================================================================================================================
+# Custom GitHub Action to draft a release
+#
+# A GitHub draft release is automatically created when the plugin's `manifest.json`
+# is updated on the `release` branch.
+#
+# Based on :
+#   - [Obsidian developers docs](https://docs.obsidian.md/Plugins/Releasing/Release+your+plugin+with+GitHub+Actions)
+#   - [Excellent tutorial for multiline strings in GitHub Actions by Thomas Stringer](https://trstringer.com/github-actions-multiline-strings/)
+# ======================================================================================================================================================
+name: "Create a draft pre-release"
+
+on:
+    # The workflow can be run manually
+    workflow_dispatch:
+    # The workflow is also triggered automatically when a push
+    # happens where the plugin's `manifest.json` is modified
+    push:
+        branches:
+            - release
+        paths:
+            - 'test-vault/.obsidian/plugins/jupyter/manifest.json'
+
+jobs:
+  create-draft-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Build plugin
+        run: |
+          npm install
+          npm run build
+
+      # To easily read JSON files and extract the version from the manifest
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.1.0
+
+      - name: Extract tag from manifest
+        # Extract the tag to use from the manifest file
+        run: |
+          tag=$(jq -r '.version' manifest.json)
+          echo "Extracted tag: $tag"
+          echo "TAG=$tag" >> $GITHUB_ENV
+
+      # Prepare a release notes template
+      - name: Prepare generic release notes
+        run: |
+          notes=$(cat <<EOF
+          Open \`.ipynb\` files, edit them and run them directly inside of Obsidian without the need to open a terminal or a browser.
+
+          Obsidian Jupyter is a plugin for [Obsidian](https://obsidian.md) that offers [Jupyter](https://jupyter.org/) Notebook and Lab integration directly into Obsidian.
+
+          ## How to install
+
+          Interested? Please follow the instructions of the [documentation](https://jupyter.mael.im) and let me hear your feedback, it enables me to keep improve the plugin. Thank you in advance !
+
+          ## Change Log
+
+          ### Features
+
+          ### Bug fixes
+
+          ### Documentation
+
+          ### Logistic
+
+          ### Development
+          EOF
+          )
+          # Thank you Thomas Stringer for this : https://trstringer.com/github-actions-multiline-strings/
+          echo "NOTES<<EOF" >> $GITHUB_ENV
+          echo "$notes" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create draft release
+        env:
+          # Extract the variables set previously from the environment
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ env.TAG }}
+          NOTES: ${{ env.NOTES }}
+        # Create a draft release with GitHub CLI
+        run: |
+          gh release create "$TAG" \
+            --title="Obsidian Jupyter v$TAG" \
+            --draft \
+            --notes "$NOTES" \
+            --generate-notes \
+            main.js manifest.json styles.css

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "obsidian-jupyter",
-	"version": "0.1.0",
-	"description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+	"description": "Open and edit Jupyter notebooks directly inside of Obsidian.",
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -136,7 +136,7 @@ export default class JupyterNotebookPlugin extends Plugin {
 		// this.settings.knownVersion = currentVersion;
 		// void this.saveSettings();
 
-		// TODO : Add a setting that allows the user to disable this feature
+		if (!this.settings.updatePopup) return;
 
 		const updateModal = new UpdateModal(this.app, this, "0.2.1-beta", "0.4.0-beta");
 		updateModal.open();
@@ -198,6 +198,11 @@ export default class JupyterNotebookPlugin extends Plugin {
 	
 	public async setMoveCheckpointsToTrash(value: boolean) {
 		this.settings.moveCheckpointsToTrash = value;
+		await this.saveSettings();
+	}
+
+	public async setUpdatePopup(value: boolean) {
+		this.settings.updatePopup = value;
 		await this.saveSettings();
 	}
 

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -124,21 +124,21 @@ export default class JupyterNotebookPlugin extends Plugin {
 		const knownVersion = this.settings.knownVersion;
 
 		// The version setting hasn't been set yet, the plugin has just been installed
-		// if (knownVersion === "") {
-		// 	return;
-		// }
+		if (knownVersion === "") {
+			return;
+		}
 
 		// The current version has already been announced
 		if (knownVersion === currentVersion) {
 			return;
 		}
 
-		// this.settings.knownVersion = currentVersion;
-		// void this.saveSettings();
+		this.settings.knownVersion = currentVersion;
+		void this.saveSettings();
 
 		if (!this.settings.updatePopup) return;
 
-		const updateModal = new UpdateModal(this.app, this, "0.2.1-beta", "0.4.0-beta");
+		const updateModal = new UpdateModal(this.app, this, knownVersion, currentVersion);
 		updateModal.open();
 	}
 

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -3,6 +3,7 @@ import { JupyterEnvironment, JupyterEnvironmentError, JupyterEnvironmentEvent, J
 import { EmbeddedJupyterView } from "./ui/jupyter-view";
 import { DEFAULT_SETTINGS, JupyterSettings, JupyterSettingsTab, PythonExecutableType } from "./jupyter-settings";
 import { JupyterModal } from "./ui/jupyter-modal";
+import { UpdateModal } from "./ui/jupyter-update-modal";
 
 export default class JupyterNotebookPlugin extends Plugin {
 
@@ -51,6 +52,8 @@ export default class JupyterNotebookPlugin extends Plugin {
 		this.registerView("jupyter-view", (leaf) => new EmbeddedJupyterView(leaf, this));
 		this.registerExtensions(["ipynb"], "jupyter-view");
 		this.addSettingTab(new JupyterSettingsTab(this.app, this));
+
+		this.announceUpdate();
 	}
 
 	async onunload() {
@@ -102,6 +105,41 @@ export default class JupyterNotebookPlugin extends Plugin {
 			}).bind(this));
 			this.env.exit();
 		}
+	}
+
+
+	/*=====================================================*/
+	/* UI Events (ribbon icon, server setting)             */
+	/*=====================================================*/
+
+	/**
+	 * Checks whether the plugin has been updated and displays a
+	 * popup message if it has.
+	 * 
+	 * Strongly inspired from the QuickAdd implementation :
+	 * https://github.com/chhoumann/quickadd/blob/08f269393c3cec5bf0c1d64a79d7999afd0a35a9/src/main.ts#L210
+	 */
+	private announceUpdate() {
+		const currentVersion = this.manifest.version;
+		const knownVersion = this.settings.knownVersion;
+
+		// The version setting hasn't been set yet, the plugin has just been installed
+		// if (knownVersion === "") {
+		// 	return;
+		// }
+
+		// The current version has already been announced
+		if (knownVersion === currentVersion) {
+			return;
+		}
+
+		// this.settings.knownVersion = currentVersion;
+		// void this.saveSettings();
+
+		// TODO : Add a setting that allows the user to disable this feature
+
+		const updateModal = new UpdateModal(this.app, this, "0.2.1-beta", "0.4.0-beta");
+		updateModal.open();
 	}
 
 

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -1,7 +1,6 @@
 import { App, DropdownComponent, Notice, PluginSettingTab, Setting, SliderComponent, TextComponent, ToggleComponent } from "obsidian";
 import JupyterNotebookPlugin from "./jupyter-obsidian";
 import { JupyterEnvironmentStatus, JupyterEnvironmentType } from "./jupyter-env";
-import { JupyterModal } from "./ui/jupyter-modal";
 import { JupyterRestartModal } from "./ui/jupyter-restart-modal";
 
 export enum PythonExecutableType {
@@ -20,6 +19,9 @@ export interface JupyterSettings {
     useStatusNotices: boolean;
     jupyterTimeoutMs: number;
     debugConsole: boolean;
+
+    // These are not for the user to modify
+    knownVersion: string;
 };
 export const DEFAULT_SETTINGS: JupyterSettings = {
     pythonExecutable: PythonExecutableType.PYTHON,
@@ -31,7 +33,9 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     displayRibbonIcon: true,
     useStatusNotices: true,
     jupyterTimeoutMs: 30000,
-    debugConsole: false
+    debugConsole: false,
+
+    knownVersion: ""
 };
 
 export class JupyterSettingsTab extends PluginSettingTab {

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -15,6 +15,7 @@ export interface JupyterSettings {
     jupyterEnvType: JupyterEnvironmentType;
     deleteCheckpoints: boolean;
     moveCheckpointsToTrash: boolean;
+    updatePopup: boolean;
     displayRibbonIcon: boolean;
     useStatusNotices: boolean;
     jupyterTimeoutMs: number;
@@ -30,6 +31,7 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     jupyterEnvType: JupyterEnvironmentType.LAB,
     deleteCheckpoints: false,
     moveCheckpointsToTrash: true,
+    updatePopup: true,
     displayRibbonIcon: true,
     useStatusNotices: true,
     jupyterTimeoutMs: 30000,
@@ -161,6 +163,16 @@ export class JupyterSettingsTab extends PluginSettingTab {
         new Setting(this.containerEl)
             .setName("Plugin customization")
             .setHeading();
+        new Setting(this.containerEl)
+            .setName("Update popup")
+            .setDesc("When the plugin is updated, a popup is shown with what changes were made.")
+            .addToggle(((toggle: ToggleComponent) => {
+                toggle
+                    .setValue(this.plugin.settings.updatePopup)
+                    .onChange(((value: boolean) => {
+                        void this.plugin.setUpdatePopup(value);
+                    }).bind(this));
+            }).bind(this));
         new Setting(this.containerEl)
             .setName("Display ribbon icon")
             .setDesc("Define whether or not you want this Jupyter plugin to use a ribbon icon.")

--- a/src/ui/jupyter-update-modal.ts
+++ b/src/ui/jupyter-update-modal.ts
@@ -141,18 +141,8 @@ export class UpdateModal extends Modal {
         }
         catch (err) {
             this.releases = [];
-            this.displayError();
+            this.display();
         }
-    }
-
-    private displayError(): void
-    {
-        const { contentEl } = this;
-        contentEl.empty();
-
-        contentEl.createEl("h1", {
-            text: "Failed to fetch release notes",
-        });
     }
 
 	private display(): void {
@@ -185,28 +175,40 @@ export class UpdateModal extends Modal {
                     }).bind(this))
             }).bind(this));
         
-        contentEl.createEl("h2", {
-            text: "What changed?"
-        });
-
-        const changeLogRegex = /## Change Log\s{1,5}([\s\S]*)$/;
 		const contentDiv = contentEl.createDiv();
-		const releaseNotes = this.releases
-			.map((release) => {
-                const results = release.body.match(changeLogRegex);
-                let changelog = results === null
-                    ? "Could not load this changelog."
-                    : results[1];
-                return `### [Jupyter for Obsidian v${release.tag_name}](https://github.com/MaelImhof/obsidian-jupyter/releases/tag/${release.tag_name})\n\n${addExtraHashToHeadings(changelog)}`;
-            })
-			.join("\n---\n");
+        
+        if (!this.releases || this.releases.length === 0) {
+            void MarkdownRenderer.render(
+                this.app,
+                `> [!FAILURE]\n> Release notes could not be retrieved. You can still look at the last releases [on GitHub](https://github.com/MaelImhof/obsidian-jupyter/releases) directly.`,
+                contentDiv,
+                this.app.vault.getRoot().path,
+                new Component()
+            );
+        }
+        else {
+            contentEl.createEl("h2", {
+                text: "What changed?"
+            });
 
-        void MarkdownRenderer.render(
-            this.app,
-            releaseNotes,
-            contentDiv,
-            this.app.vault.getRoot().path,
-            new Component()
-        );
+            const changeLogRegex = /## Change Log\s{1,5}([\s\S]*)$/;
+		    const releaseNotes = this.releases
+		    	.map((release) => {
+                    const results = release.body.match(changeLogRegex);
+                    let changelog = results === null
+                        ? "Could not load this changelog."
+                        : results[1];
+                    return `### [Jupyter for Obsidian v${release.tag_name}](https://github.com/MaelImhof/obsidian-jupyter/releases/tag/${release.tag_name})\n\n${addExtraHashToHeadings(changelog)}`;
+                })
+		    	.join("\n---\n");
+
+            void MarkdownRenderer.render(
+                this.app,
+                releaseNotes,
+                contentDiv,
+                this.app.vault.getRoot().path,
+                new Component()
+            );
+        }
 	}
 }

--- a/src/ui/jupyter-update-modal.ts
+++ b/src/ui/jupyter-update-modal.ts
@@ -7,7 +7,7 @@
  * Thank you very much @chhoumann !
  */
 
-import { App, ButtonComponent, Component, MarkdownRenderer, Modal, Setting } from "obsidian";
+import { App, ButtonComponent, Component, MarkdownRenderer, Modal, Notice, Setting } from "obsidian";
 import JupyterNotebookPlugin from "src/jupyter-obsidian";
 
 /**
@@ -179,7 +179,10 @@ export class UpdateModal extends Modal {
                 disableBtn
                     .setIcon("megaphone-off")
                     .setButtonText("Disable update popups")
-                    .onClick((() => { /* TODO : Set the setting and show a notice here */ }).bind(this))
+                    .onClick((() => {
+                        void this.plugin.setUpdatePopup(false);
+                        new Notice("Jupyter for Obsidian won't display update popups anymore.");
+                    }).bind(this))
             }).bind(this));
         
         contentEl.createEl("h2", {

--- a/src/ui/jupyter-update-modal.ts
+++ b/src/ui/jupyter-update-modal.ts
@@ -193,9 +193,7 @@ export class UpdateModal extends Modal {
 		const contentDiv = contentEl.createDiv();
 		const releaseNotes = this.releases
 			.map((release) => {
-                console.debug(release.body);
                 const results = release.body.match(changeLogRegex);
-                console.debug(results);
                 let changelog = results === null
                     ? "Could not load this changelog."
                     : results[1];

--- a/src/ui/jupyter-update-modal.ts
+++ b/src/ui/jupyter-update-modal.ts
@@ -196,7 +196,7 @@ export class UpdateModal extends Modal {
                 let changelog = results === null
                     ? "Could not load this changelog."
                     : results[1];
-                return `### Jupyter for Obsidian v${release.tag_name}\n\n${addExtraHashToHeadings(changelog)}`;
+                return `### [Jupyter for Obsidian v${release.tag_name}](https://github.com/MaelImhof/obsidian-jupyter/releases/tag/${release.tag_name})\n\n${addExtraHashToHeadings(changelog)}`;
             })
 			.join("\n---\n");
 

--- a/src/ui/jupyter-update-modal.ts
+++ b/src/ui/jupyter-update-modal.ts
@@ -1,0 +1,211 @@
+/**
+ * This file has been strongly inspired by (if not copied from)
+ * https://github.com/chhoumann/quickadd/blob/08f269393c3cec5bf0c1d64a79d7999afd0a35a9/src/gui/UpdateModal/UpdateModal.ts
+ * 
+ * Only small tweaks have been applied to adapt it for the plugin at hand.
+ * 
+ * Thank you very much @chhoumann !
+ */
+
+import { App, ButtonComponent, Component, MarkdownRenderer, Modal, Setting } from "obsidian";
+import JupyterNotebookPlugin from "src/jupyter-obsidian";
+
+/**
+ * Represents a subset of the attributes of a GitHub release.
+ */
+type Release = {
+    tag_name: string;
+    body: string;
+    draft: boolean;
+    prerelease: boolean;
+}
+
+type ErrorMessage = {
+    message: string;
+}
+
+/**
+ * Get a list of releases for a GitHub repository. Filter out drafts, only include beta
+ * releases if the current user has a beta version installed.
+ * 
+ * @param repoOwner GitHub username of the repository's owner
+ * @param repoName GitHub repository name (for example "obsidian-jupyter")
+ * @param fromRelease The tag of the last announced release (release notes for this won't be included)
+ * @param toRelease The tag of the new version to announce (release notes up to and including this will be shown)
+ * 
+ * @returns A list of releases since `fromRelease` (not included) and up to `toRelease` (included)
+ * @throws An error if the request to the API fails or specified releases are not found
+ */
+async function getReleaseNotes(repoOwner: string, repoName: string, fromRelease: string, toRelease: string): Promise<Release[]> {
+    // Get a complete list of releases from GitHub
+    const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/releases`);
+
+    // Parse the JSON response into either a list of an error
+    const releases: Release[] | ErrorMessage = await response.json();
+
+    // If the response was an error, throw one
+    if ((!response.ok && "message" in releases) || !Array.isArray(releases)) {
+        throw new Error(
+            `Failed to fetch releases: ${releases.message ?? "Unknown error"}`
+        );
+    }
+
+    // Slice the array to keep only the releases from and to the given params,
+    // Note that index 0 is the latest release, and length-1 is the first
+    const firstReleaseIndex = fromRelease === ""
+        ? releases.length
+        : releases.findIndex((release) => release.tag_name === fromRelease);
+    if (firstReleaseIndex === -1) {
+        throw new Error(`Could not find release with tag ${fromRelease}`);
+    }
+    const lastReleaseIndex = toRelease === ""
+        ? 0 // Take up to the last release
+        : releases.findIndex((release) => release.tag_name === toRelease);
+    if (lastReleaseIndex === -1) {
+        throw new Error(`Could not find release with tag ${toRelease}`);
+    }
+
+    // If the user is using beta versions of the plugin, release notes
+    // should include pre-releases, otherwise it should not
+    const beta = fromRelease.endsWith("-beta");
+
+    // Slice and filter before returning
+    return releases
+        .slice(lastReleaseIndex, firstReleaseIndex)
+        .filter((release) => !release.draft && (beta || !release.prerelease));    
+}
+
+function addExtraHashToHeadings(
+	markdownText: string,
+	numHashes = 1
+): string {
+	// Split the markdown text into an array of lines
+	const lines = markdownText.split("\n");
+
+	// Loop through each line and check if it starts with a heading syntax (#)
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i].startsWith("#")) {
+			// If the line starts with a heading syntax, add an extra '#' to the beginning
+			lines[i] = "#".repeat(numHashes) + lines[i];
+		}
+	}
+
+	// Join the array of lines back into a single string and return it
+	return lines.join("\n");
+}
+
+export class UpdateModal extends Modal {
+	private releases: Release[];
+    private lastAnnounced: string;
+    private toAnnounce: string;
+    private plugin: JupyterNotebookPlugin;
+
+	constructor(app: App, plugin: JupyterNotebookPlugin, lastAnnouncedVersion: string, versionToAnnounce: string) {
+		super(app);
+        this.plugin = plugin;
+        this.lastAnnounced = lastAnnouncedVersion;
+        this.toAnnounce = versionToAnnounce;
+
+        // Load release notes and display them asynchronously
+        void this.loadReleaseNotes();
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.createEl("h1", {
+			text: "Fetching release notes...",
+		});
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
+
+    private async loadReleaseNotes() {
+        try {
+            this.releases = await getReleaseNotes(
+                "MaelImhof",
+                "obsidian-jupyter",
+                this.lastAnnounced,
+                this.toAnnounce
+            );
+
+            if (this.releases.length === 0) {
+                this.close();
+                return;
+            }
+
+            this.display();
+        }
+        catch (err) {
+            this.releases = [];
+            this.displayError();
+        }
+    }
+
+    private displayError(): void
+    {
+        const { contentEl } = this;
+        contentEl.empty();
+
+        contentEl.createEl("h1", {
+            text: "Failed to fetch release notes",
+        });
+    }
+
+	private display(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+
+        contentEl.createEl("h1", {
+            text: `Jupyter for Obsidian v${this.toAnnounce}`
+        });
+        contentEl.createEl("p", {
+            text: "Hi !"
+        })
+        contentEl.createEl("p", {
+            text: "Thank you for using Jupyter for Obsidian, hope you like it so far ! I'd love to have your feedback if you have some time."
+        });
+        new Setting(contentEl)
+            .addButton(((feedbackBtn: ButtonComponent) => {
+                feedbackBtn
+                    .setIcon("message-circle")
+                    .setButtonText("Give feedback")
+                    .onClick(() => { window.open("https://jupyter.mael.im/#providing-feedback", "_blank"); });
+            }).bind(this))
+            .addButton(((disableBtn: ButtonComponent) => {
+                disableBtn
+                    .setIcon("megaphone-off")
+                    .setButtonText("Disable update popups")
+                    .onClick((() => { /* TODO : Set the setting and show a notice here */ }).bind(this))
+            }).bind(this));
+        
+        contentEl.createEl("h2", {
+            text: "What changed?"
+        });
+
+        const changeLogRegex = /## Change Log\s{1,5}([\s\S]*)$/;
+		const contentDiv = contentEl.createDiv();
+		const releaseNotes = this.releases
+			.map((release) => {
+                console.debug(release.body);
+                const results = release.body.match(changeLogRegex);
+                console.debug(results);
+                let changelog = results === null
+                    ? "Could not load this changelog."
+                    : results[1];
+                return `### Jupyter for Obsidian v${release.tag_name}\n\n${addExtraHashToHeadings(changelog)}`;
+            })
+			.join("\n---\n");
+
+        void MarkdownRenderer.render(
+            this.app,
+            releaseNotes,
+            contentDiv,
+            this.app.vault.getRoot().path,
+            new Component()
+        );
+	}
+}

--- a/test-vault/.obsidian/plugins/jupyter/manifest.json
+++ b/test-vault/.obsidian/plugins/jupyter/manifest.json
@@ -6,6 +6,5 @@
 	"description": "Open .ipynb files with Jupyter in Obsidian.",
 	"author": "Maël Imhof",
 	"authorUrl": "https://www.mael.im",
-	"fundingUrl": "",
 	"isDesktopOnly": true
 }


### PR DESCRIPTION
Let the user know that the plugin was updated and now has new features using a popup in Obsidian directly.

- Popup that tells the user about the changes
- The popup only appears once a change of version is detected
- The popup loads the change log from GitHub
- If the change log cannot be loaded, an error is displayed instead
- Setting to disable this popup