### PR TITLE
Added a `Start Jupyter` button to the "no automatic start" view

### DIFF
--- a/src/ui/jupyter-view.ts
+++ b/src/ui/jupyter-view.ts
@@ -65,7 +65,17 @@ export class EmbeddedJupyterView extends FileView {
                     this.plugin.toggleJupyter();
                 }
                 else {
-                    this.displayMessage("No Jupyter server", "Jupyter does not seem to be running. Please make sure to start the server manually using the plugin's ribbon icon or settings. You can also enable automatic start of the Jupyter server when a document is opened in the settings.");
+                    this.displayMessage(
+                        "No Jupyter server",
+                        "Jupyter does not seem to be running. Please make sure to start the server manually using the plugin's ribbon icon or settings. You can also enable automatic start of the Jupyter server when a document is opened in the settings.",
+                        {
+                            text: "Start Jupyter",
+                            onClick: () => {
+                                this.plugin.env.start();
+                            },
+                            closeOnClick: false
+                        }
+                    );
                     return;
                 }
                 break;


### PR DESCRIPTION
Added a Start Jupyter button to the "no automatic start" view, when the `Start Jupyter automatically` setting is disabled. This way, the user can simply click the button to start Jupyter.

## Change Log

- Copy-pasted some of my own code (had already done this for when Jupyter exited), was pretty straightforward.