### PR TITLE
Cleanup when Obsidian is closed by the user

### DIFF
--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter, Notice, Plugin, normalizePath, setIcon, setTooltip } from "obsidian";
+import { FileSystemAdapter, Notice, Plugin, Tasks, Workspace, normalizePath, setIcon, setTooltip } from "obsidian";
 import { JupyterEnvironment, JupyterEnvironmentError, JupyterEnvironmentEvent, JupyterEnvironmentStatus, JupyterEnvironmentType } from "./jupyter-env";
 import { EmbeddedJupyterView } from "./ui/jupyter-view";
 import { DEFAULT_SETTINGS, JupyterSettings, JupyterSettingsTab, PythonExecutableType } from "./jupyter-settings";
@@ -54,6 +54,11 @@ export default class JupyterNotebookPlugin extends Plugin {
 		this.registerView("jupyter-view", (leaf) => new EmbeddedJupyterView(leaf, this));
 		this.registerExtensions(["ipynb"], "jupyter-view");
 		this.addSettingTab(new JupyterSettingsTab(this.app, this));
+
+		// Try to unload when Obsidian is closed by the user/the OS
+		this.app.workspace.on('quit', async (_tasks: Tasks) => {
+			await this.onunload();
+		});
 
 		this.announceUpdate();
 	}


### PR DESCRIPTION
## Change Log

- Registered an event that unloads the plugin when Obsidian is closed

The registered event might not always work (see [this Obsidian forum post](https://forum.obsidian.md/t/cleanup-when-obsidian-is-closed/83709), some OS might kill the Obsidian process when the users wants to close it, or the user themselves might want to kill Obsidian, anyway this is some best-effort cleanup.