### PR TITLE
Create a new Jupyter notebook from within Obsidian

### DIFF
--- a/docs/content/settings.md
+++ b/docs/content/settings.md
@@ -98,6 +98,11 @@ Defines whether another ribbon icon (different from [[#Ribbon icon for server st
 This ribbon icon is independent from the server status one, meaning that it can be enabled whether the ribbon icon for server status is enabled or not, and vice-versa.
 
 Default value is yes (the ribbon icon is displayed).
+#### Folder context menu for new notebooks
+
+When right-clicking on a file or folder, Obsidian will offer some actions to the user that can be performed on this item. This setting defines whether Jupyter for Obsidian should add its own custom action to the list and offer the user to create a new Jupyter notebook when the user right-clicks on a folder.
+
+Default value is yes (the Jupyter context menu item will be available).
 #### Open created notebooks
 
 Defines whether to immediately open new notebook files when they are created, and how to open them (in a new tab, in a detached window).

--- a/docs/content/settings.md
+++ b/docs/content/settings.md
@@ -75,11 +75,20 @@ This setting allows to store the checkpoints **outside of the vault** using an a
 When the plugin gets an update, a popup will show to tell the user that a new version of Jupyter for Obsidian was installed with links to the GitHub releases and a list of the changes that were performed.
 
 This popup is enabled by default but can be disabled using this setting.
-#### Display ribbon icon
+#### Ribbon icon for server status
 
-Whether to display the plugin's ribbon icon or not. Can help if you find the ribbon icon unnecessary and want to get rid of it.
+Jupyter for Obsidian can display a ribbon icon that adapts based on the Jupyter server status (running, exited or starting). This setting defines whether that ribbon icon should be drawn.
+
+The setting is thought for users who have many plugins installed who do not want to crowd their ribbon icons bar too much.
 
 ![[ribbon-icon.png]]
+
+Default value is yes (the ribbon icon is displayed).
+#### Ribbon icon for new notebooks
+
+Defines whether another ribbon icon (different from [[#Ribbon icon for server status|the one for server status]]) is drawn. This second ribbon icon allows the user to create a new Jupyter notebook file at the root of the vault.
+
+This ribbon icon is independent from the server status one, meaning that it can be enabled whether the ribbon icon for server status is enabled or not, and vice-versa.
 
 Default value is yes (the ribbon icon is displayed).
 #### Display status notices

--- a/docs/content/settings.md
+++ b/docs/content/settings.md
@@ -104,7 +104,9 @@ Defines whether to immediately open new notebook files when they are created, an
 
 Possible values are
 - **Do not open**, simply create the file without opening it
-- **Open in a new tab**, create the file and then open it in a new tab
+- **Open in the current tab**, like the general behavior in Obsidian, replace the currently active document (if any) with the newly created notebook
+- **Open in a new tab**, create the file and then open it in a new tab, without replacing the active file
+- **Open in a new split tab**, create the file, split the current workspace and open the new notebook in the new split tab
 - **Open in a detached window**, create the file and open it in a detached window
 
 By default, new notebooks are opened in a new tab.

--- a/docs/content/settings.md
+++ b/docs/content/settings.md
@@ -98,6 +98,16 @@ Defines whether another ribbon icon (different from [[#Ribbon icon for server st
 This ribbon icon is independent from the server status one, meaning that it can be enabled whether the ribbon icon for server status is enabled or not, and vice-versa.
 
 Default value is yes (the ribbon icon is displayed).
+#### Open created notebooks
+
+Defines whether to immediately open new notebook files when they are created, and how to open them (in a new tab, in a detached window).
+
+Possible values are
+- **Do not open**, simply create the file without opening it
+- **Open in a new tab**, create the file and then open it in a new tab
+- **Open in a detached window**, create the file and open it in a detached window
+
+By default, new notebooks are opened in a new tab.
 ### Advanced
 #### Jupyter starting timeout
 

--- a/docs/content/settings.md
+++ b/docs/content/settings.md
@@ -84,6 +84,13 @@ The setting is thought for users who have many plugins installed who do not want
 ![[ribbon-icon.png]]
 
 Default value is yes (the ribbon icon is displayed).
+#### Display status notices
+
+Whether to display status notices when the Jupyter server state updates. A notice will appear every time the server is started, running, or exits.
+
+![[status-notices.png]]
+
+Default value is yes (the status notices are displayed).
 #### Ribbon icon for new notebooks
 
 Defines whether another ribbon icon (different from [[#Ribbon icon for server status|the one for server status]]) is drawn. This second ribbon icon allows the user to create a new Jupyter notebook file at the root of the vault.
@@ -91,13 +98,6 @@ Defines whether another ribbon icon (different from [[#Ribbon icon for server st
 This ribbon icon is independent from the server status one, meaning that it can be enabled whether the ribbon icon for server status is enabled or not, and vice-versa.
 
 Default value is yes (the ribbon icon is displayed).
-#### Display status notices
-
-Whether to display status notices when the Jupyter server state updates. A notice will appear every time the server is started, running, or exits. 
-
-![[status-notices.png]]
-
-Default value is yes (the status notices are displayed).
 ### Advanced
 #### Jupyter starting timeout
 

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -53,6 +53,9 @@ export default class JupyterNotebookPlugin extends Plugin {
 		if (this.settings.displayServerRibbonIcon) {
 			this.serverRibbonIcon = this.addRibbonIcon("monitor-play", "Start Jupyter Server", this.toggleJupyter.bind(this));
 		}
+		if (this.settings.displayFileRibbonIcon) {
+			this.fileRibbonIcon = this.addRibbonIcon("jupyter-logo", "Create Jupyter Notebook", this.onFileRibbonIconClicked.bind(this));
+		}
 
 		this.registerView("jupyter-view", (leaf) => new EmbeddedJupyterView(leaf, this));
 		this.registerExtensions(["ipynb"], "jupyter-view");
@@ -271,9 +274,7 @@ export default class JupyterNotebookPlugin extends Plugin {
 			this.fileRibbonIcon = null;
 		}
 		else {
-			this.fileRibbonIcon = this.addRibbonIcon("jupyter-logo", "Create Jupyter Notebook", (_event: MouseEvent) => {
-				// TODO : Implement the creation of a new Jupyter notebook file
-			});
+			this.fileRibbonIcon = this.addRibbonIcon("jupyter-logo", "Create Jupyter Notebook", this.onFileRibbonIconClicked.bind(this));
 		}
 	}
 
@@ -425,6 +426,47 @@ export default class JupyterNotebookPlugin extends Plugin {
 
 	private async onJupyterExit(_env: JupyterEnvironment) {
 		await this.purgeJupyterCheckpoints();
+	}
+
+
+	/*=====================================================*/
+	/* Jupyter checkpoints management                      */
+	/*=====================================================*/
+
+	public async onFileRibbonIconClicked() {
+		await this.createJupyterNotebook(JupyterAbstractPath.fromRelative("/", true, this.app.vault));
+	}
+
+	private getDefaultNotebookFilename(): string {
+		const now = new Date();
+		const year = now.getFullYear();
+		const month = String(now.getMonth() + 1).padStart(2, '0');
+		const day = String(now.getDate()).padStart(2, '0');
+		const hours = String(now.getHours()).padStart(2, '0');
+		const minutes = String(now.getMinutes()).padStart(2, '0');
+		const seconds = String(now.getSeconds()).padStart(2, '0');
+		return `Jupyter Notebook ${year}-${month}-${day}-${hours}-${minutes}-${seconds}.ipynb`;
+	}
+
+	private async createJupyterNotebook(folder: JupyterAbstractPath) {
+		// Check that the notebook is being created inside of the Obsidian vault
+		if (!folder.inVault()) {
+			throw new Error("Creating a new notebook can only be done within the vault.");
+		}
+
+		// Append the filename to the folder name
+		const file = folder.append(this.getDefaultNotebookFilename(), false);
+
+		// Check that the file does not already exist to avoid overwriting it
+		if (await this.app.vault.adapter.exists(file.getRelativePath() as string)) {
+			new Notice(`The file "${file.getRelativePath() as string}" already exists, creation was aborted to avoid overwriting it. Please try again.`);
+		}
+
+		// Create a Jupyter notebook with the minimum amount of content
+		await this.app.vault.adapter.write(
+			file.getRelativePath() as string,
+			`{"cells": [],"metadata": {"kernelspec": {"display_name": "","name": ""},"language_info": {"name": ""}},"nbformat": 4,"nbformat_minor": 5}`
+		);
 	}
 
 

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -1,7 +1,7 @@
 import { FileSystemAdapter, Notice, Plugin, Tasks, Workspace, addIcon, normalizePath, setIcon, setTooltip } from "obsidian";
 import { JupyterEnvironment, JupyterEnvironmentError, JupyterEnvironmentEvent, JupyterEnvironmentStatus, JupyterEnvironmentType } from "./jupyter-env";
 import { EmbeddedJupyterView } from "./ui/jupyter-view";
-import { DEFAULT_SETTINGS, JupyterSettings, JupyterSettingsTab, PythonExecutableType } from "./jupyter-settings";
+import { DEFAULT_SETTINGS, JupyterSettings, JupyterSettingsTab, OpenCreatedNotebook, PythonExecutableType } from "./jupyter-settings";
 import { JupyterModal } from "./ui/jupyter-modal";
 import { UpdateModal } from "./ui/jupyter-update-modal";
 import { rmdirSync } from "fs";
@@ -281,6 +281,11 @@ export default class JupyterNotebookPlugin extends Plugin {
 		else {
 			this.fileRibbonIcon = this.addRibbonIcon("jupyter-logo", "Create Jupyter Notebook", this.onFileRibbonIconClicked.bind(this));
 		}
+	}
+
+	public async setOpenCreatedFileMode(value: OpenCreatedNotebook) {
+		this.settings.openCreatedFileMode = value;
+		await this.saveSettings();
 	}
 
 	public async setJupyterTimeoutMs(value: number) {

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -50,7 +50,7 @@ export default class JupyterNotebookPlugin extends Plugin {
 		if (this.startEnvOnceInitialized) {
 			this.toggleJupyter();
 		}
-		if (this.settings.displayRibbonIcon) {
+		if (this.settings.displayServerRibbonIcon) {
 			this.serverRibbonIcon = this.addRibbonIcon("monitor-play", "Start Jupyter Server", this.toggleJupyter.bind(this));
 		}
 
@@ -250,8 +250,8 @@ export default class JupyterNotebookPlugin extends Plugin {
 		await this.saveSettings();
 	}
 
-	public async setRibbonIconSetting(value: boolean) {
-		this.settings.displayRibbonIcon = value;
+	public async setServerRibbonIconSetting(value: boolean) {
+		this.settings.displayServerRibbonIcon = value;
 		await this.saveSettings();
 		if (!value) {
 			this.serverRibbonIcon?.remove();
@@ -260,6 +260,20 @@ export default class JupyterNotebookPlugin extends Plugin {
 		else {
 			this.serverRibbonIcon = this.addRibbonIcon("monitor-play", "Start Jupyter Server", this.toggleJupyter.bind(this));
 			this.updateRibbon(this.env);
+		}
+	}
+
+	public async setFileRibbonIconSetting(value: boolean) {
+		this.settings.displayFileRibbonIcon = value;
+		await this.saveSettings();
+		if (!value) {
+			this.fileRibbonIcon?.remove();
+			this.fileRibbonIcon = null;
+		}
+		else {
+			this.fileRibbonIcon = this.addRibbonIcon("jupyter-logo", "Create Jupyter Notebook", (_event: MouseEvent) => {
+				// TODO : Implement the creation of a new Jupyter notebook file
+			});
 		}
 	}
 
@@ -389,7 +403,7 @@ export default class JupyterNotebookPlugin extends Plugin {
 	}
 
 	private async updateRibbon(env: JupyterEnvironment) {
-		if (this.serverRibbonIcon === null || !this.settings.displayRibbonIcon) {
+		if (this.serverRibbonIcon === null || !this.settings.displayServerRibbonIcon) {
 			return;
 		}
 

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -14,7 +14,8 @@ export default class JupyterNotebookPlugin extends Plugin {
 	/*=====================================================*/
 
 	public settings: JupyterSettings = DEFAULT_SETTINGS;
-	private ribbonIcon: HTMLElement|null = null;
+	private serverRibbonIcon: HTMLElement|null = null;
+	private fileRibbonIcon: HTMLElement|null = null;
 
 	public readonly env: JupyterEnvironment = new JupyterEnvironment(
 		(this.app.vault.adapter as FileSystemAdapter).getBasePath(),
@@ -49,7 +50,9 @@ export default class JupyterNotebookPlugin extends Plugin {
 		if (this.startEnvOnceInitialized) {
 			this.toggleJupyter();
 		}
-		this.ribbonIcon = this.addRibbonIcon("monitor-play", "Start Jupyter Server", this.toggleJupyter.bind(this));
+		if (this.settings.displayRibbonIcon) {
+			this.serverRibbonIcon = this.addRibbonIcon("monitor-play", "Start Jupyter Server", this.toggleJupyter.bind(this));
+		}
 
 		this.registerView("jupyter-view", (leaf) => new EmbeddedJupyterView(leaf, this));
 		this.registerExtensions(["ipynb"], "jupyter-view");
@@ -251,11 +254,11 @@ export default class JupyterNotebookPlugin extends Plugin {
 		this.settings.displayRibbonIcon = value;
 		await this.saveSettings();
 		if (!value) {
-			this.ribbonIcon?.remove();
-			this.ribbonIcon = null;
+			this.serverRibbonIcon?.remove();
+			this.serverRibbonIcon = null;
 		}
 		else {
-			this.ribbonIcon = this.addRibbonIcon("monitor-play", "Start Jupyter Server", this.toggleJupyter.bind(this));
+			this.serverRibbonIcon = this.addRibbonIcon("monitor-play", "Start Jupyter Server", this.toggleJupyter.bind(this));
 			this.updateRibbon(this.env);
 		}
 	}
@@ -386,22 +389,22 @@ export default class JupyterNotebookPlugin extends Plugin {
 	}
 
 	private async updateRibbon(env: JupyterEnvironment) {
-		if (this.ribbonIcon === null || !this.settings.displayRibbonIcon) {
+		if (this.serverRibbonIcon === null || !this.settings.displayRibbonIcon) {
 			return;
 		}
 
 		switch (env.getStatus()) {
 			case JupyterEnvironmentStatus.STARTING:
-				setIcon(this.ribbonIcon as HTMLElement, "monitor-dot");
-				setTooltip(this.ribbonIcon as HTMLElement, "Jupyter Server is starting");
+				setIcon(this.serverRibbonIcon as HTMLElement, "monitor-dot");
+				setTooltip(this.serverRibbonIcon as HTMLElement, "Jupyter Server is starting");
 				break;
 			case JupyterEnvironmentStatus.RUNNING:
-				setIcon(this.ribbonIcon as HTMLElement, "monitor-stop");
-				setTooltip(this.ribbonIcon as HTMLElement, "Stop Jupyter Server");
+				setIcon(this.serverRibbonIcon as HTMLElement, "monitor-stop");
+				setTooltip(this.serverRibbonIcon as HTMLElement, "Stop Jupyter Server");
 				break;
 			case JupyterEnvironmentStatus.EXITED:
-				setIcon(this.ribbonIcon as HTMLElement, "monitor-play");
-				setTooltip(this.ribbonIcon as HTMLElement, "Start Jupyter Server");
+				setIcon(this.serverRibbonIcon as HTMLElement, "monitor-play");
+				setTooltip(this.serverRibbonIcon as HTMLElement, "Start Jupyter Server");
 				break;
 		}
 	}

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -61,6 +61,13 @@ export default class JupyterNotebookPlugin extends Plugin {
 		if (this.settings.displayFolderContextMenuItem) {
 			this.app.workspace.on('file-menu', this.onFileContextMenu);
 		}
+		this.addCommand({
+			id: "jupyter-create-notebook",
+			name: "Create new Jupyter notebook",
+			callback: (async () => {
+				await this.createJupyterNotebook(JupyterAbstractPath.fromRelative("/", true, this.app.vault));
+			}).bind(this)
+		});
 
 		this.registerView("jupyter-view", (leaf) => new EmbeddedJupyterView(leaf, this));
 		this.registerExtensions(["ipynb"], "jupyter-view");

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter, Notice, PaneType, Plugin, TFile, Tasks, Workspace, WorkspaceLeaf, addIcon, normalizePath, setIcon, setTooltip } from "obsidian";
+import { FileSystemAdapter, Menu, MenuItem, Notice, PaneType, Plugin, TAbstractFile, TFile, TFolder, Tasks, WorkspaceLeaf, addIcon, normalizePath, setIcon, setTooltip } from "obsidian";
 import { JupyterEnvironment, JupyterEnvironmentError, JupyterEnvironmentEvent, JupyterEnvironmentStatus, JupyterEnvironmentType } from "./jupyter-env";
 import { EmbeddedJupyterView } from "./ui/jupyter-view";
 import { DEFAULT_SETTINGS, JupyterSettings, JupyterSettingsTab, OpenCreatedNotebook, PythonExecutableType } from "./jupyter-settings";
@@ -16,6 +16,8 @@ export default class JupyterNotebookPlugin extends Plugin {
 	public settings: JupyterSettings = DEFAULT_SETTINGS;
 	private serverRibbonIcon: HTMLElement|null = null;
 	private fileRibbonIcon: HTMLElement|null = null;
+
+	private onFileContextMenu = this.onFileContextMenuOpened.bind(this);
 
 	public readonly env: JupyterEnvironment = new JupyterEnvironment(
 		(this.app.vault.adapter as FileSystemAdapter).getBasePath(),
@@ -56,6 +58,9 @@ export default class JupyterNotebookPlugin extends Plugin {
 		if (this.settings.displayFileRibbonIcon) {
 			this.fileRibbonIcon = this.addRibbonIcon("jupyter-logo", "Create Jupyter Notebook", this.onFileRibbonIconClicked.bind(this));
 		}
+		if (this.settings.displayFolderContextMenuItem) {
+			this.app.workspace.on('file-menu', this.onFileContextMenu);
+		}
 
 		this.registerView("jupyter-view", (leaf) => new EmbeddedJupyterView(leaf, this));
 		this.registerExtensions(["ipynb"], "jupyter-view");
@@ -90,6 +95,7 @@ export default class JupyterNotebookPlugin extends Plugin {
 		// Kill the Jupyter Notebook process
 		this.env.exit();
 		await this.purgeJupyterCheckpoints();
+		this.app.workspace.off('file-menu', this.onFileContextMenu);
 	}
 
 
@@ -283,6 +289,17 @@ export default class JupyterNotebookPlugin extends Plugin {
 		}
 	}
 
+	public async setFolderContextMenuSetting(value: boolean) {
+		this.settings.displayFolderContextMenuItem = value;
+		await this.saveSettings();
+		if (!value) {
+			this.app.workspace.off('file-menu', this.onFileContextMenu);
+		}
+		else {
+			this.app.workspace.on('file-menu', this.onFileContextMenu);
+		}
+	}
+
 	public async setOpenCreatedFileMode(value: OpenCreatedNotebook) {
 		this.settings.openCreatedFileMode = value;
 		await this.saveSettings();
@@ -440,6 +457,23 @@ export default class JupyterNotebookPlugin extends Plugin {
 
 	public async onFileRibbonIconClicked() {
 		await this.createJupyterNotebook(JupyterAbstractPath.fromRelative("/", true, this.app.vault));
+	}
+
+	public onFileContextMenuOpened(menu: Menu, file: TAbstractFile, _source: string, _leaf?: WorkspaceLeaf) {
+		// Only propose to create a Jupyter Notebook in folders
+		if (file instanceof TFolder) {
+			menu.addItem((item: MenuItem) => {
+				item
+					.setTitle("New Jupyter notebook")
+					.setIcon("jupyter-logo")
+					.setSection("action-primary")
+					.onClick(async (_event: MouseEvent|KeyboardEvent) => {
+						console.debug(file.path);
+						console.debug(JupyterAbstractPath.fromRelative(file.path, true, this.app.vault).getRelativePath());
+						await this.createJupyterNotebook(JupyterAbstractPath.fromRelative(file.path, true, this.app.vault));
+					});
+			});
+		}
 	}
 
 	private getDefaultNotebookFilename(): string {

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter, Notice, Plugin, Tasks, Workspace, normalizePath, setIcon, setTooltip } from "obsidian";
+import { FileSystemAdapter, Notice, Plugin, Tasks, Workspace, addIcon, normalizePath, setIcon, setTooltip } from "obsidian";
 import { JupyterEnvironment, JupyterEnvironmentError, JupyterEnvironmentEvent, JupyterEnvironmentStatus, JupyterEnvironmentType } from "./jupyter-env";
 import { EmbeddedJupyterView } from "./ui/jupyter-view";
 import { DEFAULT_SETTINGS, JupyterSettings, JupyterSettingsTab, PythonExecutableType } from "./jupyter-settings";
@@ -54,6 +54,22 @@ export default class JupyterNotebookPlugin extends Plugin {
 		this.registerView("jupyter-view", (leaf) => new EmbeddedJupyterView(leaf, this));
 		this.registerExtensions(["ipynb"], "jupyter-view");
 		this.addSettingTab(new JupyterSettingsTab(this.app, this));
+
+		/*
+		 * The icon used is derived from `coreui`'s Jupyter SVG Vector icon :
+		 * https://www.svgrepo.com/svg/341956/jupyter
+		 * 
+		 * It was adjusted to be a custom icon in Obsidian :
+		 * - Removed the surrounding SVG tags
+		 * - Resized to fit a viewBox of "0 0 100 100"
+		 * - Added the fill="currentColor" property to adapt to Obsidian's theme
+		 * For more information about those modifications, see Obsidian's documentation :
+		 * https://docs.obsidian.md/Plugins/User+interface/Icons#Add+your+own+icon
+		 * 
+		 * Provided under the terms of the GPL license :
+		 * https://www.svgrepo.com/page/licensing/#GPL
+		 */
+		addIcon("jupyter-logo", `<path fill="currentColor" d="m 51.4537,74.98344 c -15.406714,0 -29.180954,-5.68784 -36.479994,-13.79248 2.83328,7.29904 7.71248,13.79248 14.187674,18.24 6.493446,4.46576 14.187686,6.8856 22.29232,6.8856 8.10464,0 15.82016,-2.41984 22.29232,-6.8856 C 80.239467,74.98344 85.100427,68.49 87.933707,61.19096 80.634667,69.29864 66.86042,74.98344 51.4537,74.98344 Z m 0,-53.5192 c 15.40672,0 29.180967,5.68784 36.480007,13.79248 -2.83328,-7.29904 -7.69424,-13.79248 -14.187687,-18.24 -6.8856,-4.86096 -14.57984,-7.29904 -22.29232,-7.29904 -8.107674,0 -15.798874,2.44112 -22.29232,6.8856 C 22.689226,21.46424 17.806986,27.54424 14.973706,35.25672 22.272746,26.7356 35.654826,21.46424 51.4537,21.46424 Z M 79.829067,2.02344 c -7.566567,0 -7.566567,11.33312 0,11.33312 7.56656,0 7.56656,-11.33312 0,-11.33312 z M 22.689226,83.89672 c -4.04016,0 -7.299046,3.25888 -7.299046,7.29904 0,4.02192 3.258886,7.2808 7.299046,7.2808 4.021914,0 7.280794,-3.25888 7.280794,-7.2808 0,-4.04016 -3.258874,-7.29904 -7.280794,-7.29904 z m -6.08,-72.96 c -5.414243,0 -5.414243,8.10768 0,8.10768 5.399034,0 5.399034,-8.10768 0,-8.10768 z" id="path1" style="stroke-width:3.04" />`);
 
 		// Try to unload when Obsidian is closed by the user/the OS
 		this.app.workspace.on('quit', async (_tasks: Tasks) => {

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -266,6 +266,11 @@ export default class JupyterNotebookPlugin extends Plugin {
 		}
 	}
 
+	public async setStatusNoticesSetting(value: boolean) {
+		this.settings.useStatusNotices = value;
+		await this.saveSettings();
+	}
+
 	public async setFileRibbonIconSetting(value: boolean) {
 		this.settings.displayFileRibbonIcon = value;
 		await this.saveSettings();
@@ -276,11 +281,6 @@ export default class JupyterNotebookPlugin extends Plugin {
 		else {
 			this.fileRibbonIcon = this.addRibbonIcon("jupyter-logo", "Create Jupyter Notebook", this.onFileRibbonIconClicked.bind(this));
 		}
-	}
-
-	public async setStatusNoticesSetting(value: boolean) {
-		this.settings.useStatusNotices = value;
-		await this.saveSettings();
 	}
 
 	public async setJupyterTimeoutMs(value: number) {

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -1,4 +1,4 @@
-import { FileSystemAdapter, Notice, Plugin, Tasks, Workspace, addIcon, normalizePath, setIcon, setTooltip } from "obsidian";
+import { FileSystemAdapter, Notice, PaneType, Plugin, TFile, Tasks, Workspace, WorkspaceLeaf, addIcon, normalizePath, setIcon, setTooltip } from "obsidian";
 import { JupyterEnvironment, JupyterEnvironmentError, JupyterEnvironmentEvent, JupyterEnvironmentStatus, JupyterEnvironmentType } from "./jupyter-env";
 import { EmbeddedJupyterView } from "./ui/jupyter-view";
 import { DEFAULT_SETTINGS, JupyterSettings, JupyterSettingsTab, OpenCreatedNotebook, PythonExecutableType } from "./jupyter-settings";
@@ -472,6 +472,27 @@ export default class JupyterNotebookPlugin extends Plugin {
 			file.getRelativePath() as string,
 			`{"cells": [],"metadata": {"kernelspec": {"display_name": "","name": ""},"language_info": {"name": ""}},"nbformat": 4,"nbformat_minor": 5}`
 		);
+
+		// Depending on the corresponding setting, open the created notebook
+		if (this.settings.openCreatedFileMode !== OpenCreatedNotebook.DONT) {
+			let newLeaf: PaneType|boolean;
+			switch (this.settings.openCreatedFileMode) {
+				case OpenCreatedNotebook.CURRENT_TAB:
+					newLeaf = false;
+					break;
+				case OpenCreatedNotebook.NEW_TAB:
+					newLeaf = 'tab';
+					break;
+				case OpenCreatedNotebook.SPLIT:
+					newLeaf = 'split';
+					break;
+				case OpenCreatedNotebook.WINDOW:
+					newLeaf = 'window';
+					break;
+			}
+			const leaf = this.app.workspace.getLeaf(newLeaf);
+			leaf.openFile(this.app.vault.getFileByPath(file.getRelativePath() as string) as TFile);
+		}
 	}
 
 

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -22,8 +22,8 @@ export interface JupyterSettings {
     checkpointsFolder: string;
     updatePopup: boolean;
     displayServerRibbonIcon: boolean;
-    displayFileRibbonIcon: boolean;
     useStatusNotices: boolean;
+    displayFileRibbonIcon: boolean;
     jupyterTimeoutMs: number;
     debugConsole: boolean;
 
@@ -40,8 +40,8 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     checkpointsFolder: "",
     updatePopup: true,
     displayServerRibbonIcon: true,
-    displayFileRibbonIcon: true,
     useStatusNotices: true,
+    displayFileRibbonIcon: true,
     jupyterTimeoutMs: 30000,
     debugConsole: false,
 
@@ -203,16 +203,6 @@ export class JupyterSettingsTab extends PluginSettingTab {
                     }).bind(this))
             ).bind(this));
         new Setting(this.containerEl)
-            .setName("Ribbon icon for new notebooks")
-            .setDesc("Whether to display a ribbon icon that creates a blank Jupyter notebook when clicked.")
-            .addToggle(((toggle: ToggleComponent) =>
-                toggle
-                    .setValue(this.plugin.settings.displayFileRibbonIcon)
-                    .onChange((async (value: boolean) => {
-                        await this.plugin.setFileRibbonIconSetting(value);
-                    }).bind(this))
-            ).bind(this));
-        new Setting(this.containerEl)
             .setName("Display status notices")
             .setDesc("If enabled, short messages will pop up when the Jupyter server is starting, running or exits.")
             .addToggle(((toggle: ToggleComponent) =>
@@ -220,6 +210,16 @@ export class JupyterSettingsTab extends PluginSettingTab {
                     .setValue(this.plugin.settings.useStatusNotices)
                     .onChange((async (value: boolean) => {
                         await this.plugin.setStatusNoticesSetting(value);
+                    }).bind(this))
+            ).bind(this));
+        new Setting(this.containerEl)
+            .setName("Ribbon icon for new notebooks")
+            .setDesc("Whether to display a ribbon icon that creates a blank Jupyter notebook when clicked.")
+            .addToggle(((toggle: ToggleComponent) =>
+                toggle
+                    .setValue(this.plugin.settings.displayFileRibbonIcon)
+                    .onChange((async (value: boolean) => {
+                        await this.plugin.setFileRibbonIconSetting(value);
                     }).bind(this))
             ).bind(this));
 

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -10,7 +10,9 @@ export enum PythonExecutableType {
 
 export enum OpenCreatedNotebook {
     DONT = "dont-open",
-    TAB = "new-tab",
+    CURRENT_TAB = "current-tab",
+    NEW_TAB = "new-tab",
+    SPLIT = "split",
     WINDOW = "detached-window"
 }
 
@@ -49,7 +51,7 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     displayServerRibbonIcon: true,
     useStatusNotices: true,
     displayFileRibbonIcon: true,
-    openCreatedFileMode: OpenCreatedNotebook.TAB,
+    openCreatedFileMode: OpenCreatedNotebook.CURRENT_TAB,
     jupyterTimeoutMs: 30000,
     debugConsole: false,
 
@@ -236,7 +238,9 @@ export class JupyterSettingsTab extends PluginSettingTab {
             .addDropdown(((dropdown: DropdownComponent) => {
                 dropdown
                     .addOption(OpenCreatedNotebook.DONT, "Do not open")
-                    .addOption(OpenCreatedNotebook.TAB, "Open in a new tab")
+                    .addOption(OpenCreatedNotebook.CURRENT_TAB, "Open in the current tab (default)")
+                    .addOption(OpenCreatedNotebook.NEW_TAB, "Open in a new tab")
+                    .addOption(OpenCreatedNotebook.SPLIT, "Open in a new split tab")
                     .addOption(OpenCreatedNotebook.WINDOW, "Open in a detached window")
                     .setValue(this.plugin.settings.openCreatedFileMode)
                     .onChange((async (value: OpenCreatedNotebook) => {

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -32,6 +32,7 @@ export interface JupyterSettings {
     displayServerRibbonIcon: boolean;
     useStatusNotices: boolean;
     displayFileRibbonIcon: boolean;
+    displayFolderContextMenuItem: boolean;
     openCreatedFileMode: OpenCreatedNotebook,
     jupyterTimeoutMs: number;
     debugConsole: boolean;
@@ -51,6 +52,7 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     displayServerRibbonIcon: true,
     useStatusNotices: true,
     displayFileRibbonIcon: true,
+    displayFolderContextMenuItem: true,
     openCreatedFileMode: OpenCreatedNotebook.CURRENT_TAB,
     jupyterTimeoutMs: 30000,
     debugConsole: false,
@@ -230,6 +232,16 @@ export class JupyterSettingsTab extends PluginSettingTab {
                     .setValue(this.plugin.settings.displayFileRibbonIcon)
                     .onChange((async (value: boolean) => {
                         await this.plugin.setFileRibbonIconSetting(value);
+                    }).bind(this))
+            ).bind(this));
+        new Setting(this.containerEl)
+            .setName("Folder context menu for new notebooks")
+            .setDesc("If enabled, when you right-click on a folder, one of the actions will be to create a new Jupyter notebook in that folder.")
+            .addToggle(((toggle: ToggleComponent) =>
+                toggle
+                    .setValue(this.plugin.settings.displayFolderContextMenuItem)
+                    .onChange((async (value: boolean) => {
+                        await this.plugin.setFolderContextMenuSetting(value);
                     }).bind(this))
             ).bind(this));
         new Setting(this.containerEl)

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -21,7 +21,8 @@ export interface JupyterSettings {
      */
     checkpointsFolder: string;
     updatePopup: boolean;
-    displayRibbonIcon: boolean;
+    displayServerRibbonIcon: boolean;
+    displayFileRibbonIcon: boolean;
     useStatusNotices: boolean;
     jupyterTimeoutMs: number;
     debugConsole: boolean;
@@ -38,7 +39,8 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     moveCheckpointsToTrash: true,
     checkpointsFolder: "",
     updatePopup: true,
-    displayRibbonIcon: true,
+    displayServerRibbonIcon: true,
+    displayFileRibbonIcon: true,
     useStatusNotices: true,
     jupyterTimeoutMs: 30000,
     debugConsole: false,
@@ -191,13 +193,23 @@ export class JupyterSettingsTab extends PluginSettingTab {
                     }).bind(this));
             }).bind(this));
         new Setting(this.containerEl)
-            .setName("Display ribbon icon")
-            .setDesc("Define whether or not you want this Jupyter plugin to use a ribbon icon.")
+            .setName("Ribbon icon for server status")
+            .setDesc("Whether to display a ribbon icon that indicates the server status (exited, starting, running), which can be used to start/stop the server.")
             .addToggle(((toggle: ToggleComponent) =>
                 toggle
-                    .setValue(this.plugin.settings.displayRibbonIcon)
+                    .setValue(this.plugin.settings.displayServerRibbonIcon)
                     .onChange((async (value: boolean) => {
-                        await this.plugin.setRibbonIconSetting(value);
+                        await this.plugin.setServerRibbonIconSetting(value);
+                    }).bind(this))
+            ).bind(this));
+        new Setting(this.containerEl)
+            .setName("Ribbon icon for new notebooks")
+            .setDesc("Whether to display a ribbon icon that creates a blank Jupyter notebook when clicked.")
+            .addToggle(((toggle: ToggleComponent) =>
+                toggle
+                    .setValue(this.plugin.settings.displayFileRibbonIcon)
+                    .onChange((async (value: boolean) => {
+                        await this.plugin.setFileRibbonIconSetting(value);
                     }).bind(this))
             ).bind(this));
         new Setting(this.containerEl)

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -8,6 +8,12 @@ export enum PythonExecutableType {
     PATH = "path"
 }
 
+export enum OpenCreatedNotebook {
+    DONT = "dont-open",
+    TAB = "new-tab",
+    WINDOW = "detached-window"
+}
+
 export interface JupyterSettings {
     pythonExecutable: PythonExecutableType;
     pythonExecutablePath: string;
@@ -24,6 +30,7 @@ export interface JupyterSettings {
     displayServerRibbonIcon: boolean;
     useStatusNotices: boolean;
     displayFileRibbonIcon: boolean;
+    openCreatedFileMode: OpenCreatedNotebook,
     jupyterTimeoutMs: number;
     debugConsole: boolean;
 
@@ -42,6 +49,7 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     displayServerRibbonIcon: true,
     useStatusNotices: true,
     displayFileRibbonIcon: true,
+    openCreatedFileMode: OpenCreatedNotebook.TAB,
     jupyterTimeoutMs: 30000,
     debugConsole: false,
 
@@ -222,6 +230,19 @@ export class JupyterSettingsTab extends PluginSettingTab {
                         await this.plugin.setFileRibbonIconSetting(value);
                     }).bind(this))
             ).bind(this));
+        new Setting(this.containerEl)
+            .setName("Open created notebooks")
+            .setDesc("Whether to open a notebook directly when it is created, and how to open it.")
+            .addDropdown(((dropdown: DropdownComponent) => {
+                dropdown
+                    .addOption(OpenCreatedNotebook.DONT, "Do not open")
+                    .addOption(OpenCreatedNotebook.TAB, "Open in a new tab")
+                    .addOption(OpenCreatedNotebook.WINDOW, "Open in a detached window")
+                    .setValue(this.plugin.settings.openCreatedFileMode)
+                    .onChange((async (value: OpenCreatedNotebook) => {
+                        await this.plugin.setOpenCreatedFileMode(value);
+                    }).bind(this));
+            }).bind(this));
 
 
         /*=====================================================*/

--- a/src/utils/jupyter-path.ts
+++ b/src/utils/jupyter-path.ts
@@ -98,7 +98,7 @@ export class JupyterAbstractPath {
             absolute += "/";
         }
         else if (!isFolder && absolute.endsWith("/")) {
-            absolute.substring(0, absolute.length - 1);
+            absolute = absolute.substring(0, absolute.length - 1);
         }
         this.absolutePath = absolute;
 
@@ -110,6 +110,12 @@ export class JupyterAbstractPath {
             throw new Error("Invalid argument in JupyterAbstractPath constructor : `relative` must not be `null` if `isInVault` is set to `true`");
         }
         else {
+            if (isFolder && !relative.endsWith('/')) {
+                relative += '/';
+            }
+            else if (!isFolder && relative.endsWith('/')) {
+                relative = relative.substring(0, absolute.length - 1);
+            }
             this.relativePath = relative;
         }
 

--- a/test-vault/Notebook creation/Valid notebook.ipynb
+++ b/test-vault/Notebook creation/Valid notebook.ipynb
@@ -1,0 +1,14 @@
+{
+ "cells": [],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "",
+   "name": ""
+  },
+  "language_info": {
+   "name": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Change Log

- Added a setting to display (or not display) a ribbon icon that creates a new Jupyter notebook file at the root of the vault
- Added a setting to display (or not display) a folder context menu item to create a new Jupyter notebook inside the right-clicked folder
- Added an Obsidian command that creates a new Jupyter notebook file at the root of the vault
- Added a setting to define how a newly created Jupyter notebook should be opened (not at all, in the current tab, in a new tab, ...)
- Fixed a bug in `JupyterAbstractPath`, now it effectively guarantees that folder paths will end with `'/'`
- Added new test notebooks to the test vault