### PR TITLE
Updating `dev` before I can merge the new release

### DIFF
--- a/.github/workflows/release-pr-safeguard.yaml
+++ b/.github/workflows/release-pr-safeguard.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Check PR Base Branch
       run: |
-        if [[ "${{ github.base_ref }}" != "dev" ]]; then
+        if [[ "${{ github.head_ref }}" != "dev" ]]; then
           echo "Pull requests to the release branch must come from the dev branch."
           exit 1
         fi

--- a/.github/workflows/release-pr-safeguard.yaml
+++ b/.github/workflows/release-pr-safeguard.yaml
@@ -1,0 +1,17 @@
+name: Safeguard for release PRs
+
+on:
+  pull_request:
+    branches:
+      - release
+
+jobs:
+  restrict-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check PR Base Branch
+      run: |
+        if [[ "${{ github.base_ref }}" != "dev" ]]; then
+          echo "Pull requests to the release branch must come from the dev branch."
+          exit 1
+        fi


### PR DESCRIPTION
This is tedious, but I prefer this so that I keep in mind where the state is at all times.