### PR TITLE
Simple Interface setting for Jupyter Lab

### DIFF
--- a/docs/content/settings.md
+++ b/docs/content/settings.md
@@ -34,6 +34,15 @@ Whether to use Jupyter Lab or Jupyter Notebook.
 Note that if the Jupyter server is running while you change this setting, you will need to stop it and start it again for the new value to take effect.
 
 Default value is Jupyter Lab.
+#### Simple Interface
+
+Jupyter Lab provides an appearance setting called `Simple Interface`. It hides unnecessary UI elements for the user to concentrate on the file that is being edited. No Jupyter tabs, no sidebars, just the file.
+
+This setting defines whether notebooks should be opened in `Simple Interface` mode by default.
+
+**Has no effect** if the [[#Jupyter environment type|environment type]] is Jupyter Notebook.
+
+Default value is enabled (meaning all notebooks will be opened in `Simple Interface` mode).
 #### Delete Jupyter checkpoints
 
 When working with notebooks, Jupyter generates checkpoint files. This creates a new `.ipynb_checkpoints` directory in each directory where you have a notebook opened. It becomes messy very fast.

--- a/src/jupyter-env.ts
+++ b/src/jupyter-env.ts
@@ -60,7 +60,15 @@ export class JupyterEnvironment {
     private jupyterTimoutListener: Debouncer<unknown[], unknown> = debounce(this.onJupyterTimeout.bind(this), this.jupyterTimeoutMs, true);
     private jupyerTimedOut: boolean = false;
 
-    constructor(private readonly path: string, private printDebug: boolean, private pythonExecutable: string, private jupyterTimeoutMs: number, private type: JupyterEnvironmentType, private customConfigFolderPath: string|null) { }
+    constructor(
+        private readonly path: string,
+        private printDebug: boolean,
+        private pythonExecutable: string,
+        private jupyterTimeoutMs: number,
+        private type: JupyterEnvironmentType,
+        private customConfigFolderPath: string|null,
+        private useSimpleMode: boolean
+    ) { }
 
     public on(event: JupyterEnvironmentEvent, callback: (env: JupyterEnvironment) => void) {
         this.events.on(event, callback);
@@ -181,6 +189,14 @@ export class JupyterEnvironment {
         return this.customConfigFolderPath;
     }
 
+    public setUseSimpleMode(value: boolean) {
+        this.useSimpleMode = value;
+    }
+
+    public getUseSimpleMode(): boolean {
+        return this.useSimpleMode;
+    }
+
     public getJupyterTimeoutMs(): number {
         return this.jupyterTimeoutMs;
     }
@@ -214,14 +230,25 @@ export class JupyterEnvironment {
     }
 
     /**
-     * @param file The path of the file relative to the Jupyter environment's working directy.
+     * @param file The path of the file relative to the Jupyter environment's working directory.
      */
     public getFileUrl(file: string): string|null {
         if (!this.isRunning()) {
             return null;
         }
 
-        return `http://localhost:${this.jupyterPort}/${this.runningType === JupyterEnvironmentType.NOTEBOOK ? "notebooks" : "lab/tree"}/${file}?token=${this.jupyterToken}`;
+        return "http://localhost:" + this.jupyterPort + "/"
+            + (
+                this.runningType === JupyterEnvironmentType.NOTEBOOK
+                ? "notebooks"
+                : (
+                    this.useSimpleMode
+                    ? "doc/tree"
+                    : "lab/tree"
+                )
+            ) + "/"
+            + file
+            + "?token=" + this.jupyterToken;
     }
 
     public exit() {

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -25,7 +25,8 @@ export default class JupyterNotebookPlugin extends Plugin {
 		DEFAULT_SETTINGS.pythonExecutable === PythonExecutableType.PYTHON ? "python" : DEFAULT_SETTINGS.pythonExecutablePath,
 		DEFAULT_SETTINGS.jupyterTimeoutMs,
 		DEFAULT_SETTINGS.jupyterEnvType,
-		null
+		null,
+		DEFAULT_SETTINGS.useSimpleMode
 	);
 	private envProperlyInitialized = false;
 	private startEnvOnceInitialized = false;
@@ -228,6 +229,12 @@ export default class JupyterNotebookPlugin extends Plugin {
 		this.settings.jupyterEnvType = value;
 		await this.saveSettings();
 		this.env.setType(value);
+	}
+
+	public async setUseSimpleMode(value: boolean) {
+		this.settings.useSimpleMode = value;
+		await this.saveSettings();
+		this.env.setUseSimpleMode(value);
 	}
 
 	public async setDeleteCheckpoints(value: boolean) {

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -21,6 +21,7 @@ export interface JupyterSettings {
     pythonExecutablePath: string;
     startJupyterAuto: boolean;
     jupyterEnvType: JupyterEnvironmentType;
+    useSimpleMode: boolean;
     deleteCheckpoints: boolean;
     moveCheckpointsToTrash: boolean;
     /**
@@ -45,6 +46,7 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     pythonExecutablePath: "",
     startJupyterAuto: true,
     jupyterEnvType: JupyterEnvironmentType.LAB,
+    useSimpleMode: true,
     deleteCheckpoints: false,
     moveCheckpointsToTrash: true,
     checkpointsFolder: "",
@@ -149,6 +151,16 @@ export class JupyterSettingsTab extends PluginSettingTab {
                             new JupyterRestartModal(this.plugin, "Jupyter environment type").open();
                         }
                     }).bind(this));
+            }).bind(this));
+        new Setting(this.containerEl)
+            .setName("Simple interface")
+            .setDesc("Whether to use Jupyter's Simple Interface mode when opening a notebook.")
+            .addToggle(((toggle: ToggleComponent) => {
+                toggle
+                    .setValue(this.plugin.settings.useSimpleMode)
+                    .onChange((async (value: boolean) => {
+                        await this.plugin.setUseSimpleMode(value);
+                    }).bind(this))
             }).bind(this));
         new Setting(this.containerEl)
             .setName("Delete Jupyter checkpoints")


### PR DESCRIPTION
Addresses #89 by providing a plugin setting to open notebooks with Jupyter Lab in Simple Interface mode by default.

This has no effect whatsoever if the user uses Jupyter Notebook.