### PR TITLE
Beta release `0.6.0-beta`

### DIFF
--- a/docs/content/settings.md
+++ b/docs/content/settings.md
@@ -34,6 +34,15 @@ Whether to use Jupyter Lab or Jupyter Notebook.
 Note that if the Jupyter server is running while you change this setting, you will need to stop it and start it again for the new value to take effect.
 
 Default value is Jupyter Lab.
+#### Simple Interface
+
+Jupyter Lab provides an appearance setting called `Simple Interface`. It hides unnecessary UI elements for the user to concentrate on the file that is being edited. No Jupyter tabs, no sidebars, just the file.
+
+This setting defines whether notebooks should be opened in `Simple Interface` mode by default.
+
+**Has no effect** if the [[#Jupyter environment type|environment type]] is Jupyter Notebook.
+
+Default value is enabled (meaning all notebooks will be opened in `Simple Interface` mode).
 #### Delete Jupyter checkpoints
 
 When working with notebooks, Jupyter generates checkpoint files. This creates a new `.ipynb_checkpoints` directory in each directory where you have a notebook opened. It becomes messy very fast.

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "jupyter",
 	"name": "Jupyter",
-	"version": "0.5.0-beta",
+	"version": "0.6.0-beta",
 	"minAppVersion": "0.15.0",
 	"description": "Open .ipynb files with Jupyter in Obsidian.",
 	"author": "Maël Imhof",

--- a/src/jupyter-env.ts
+++ b/src/jupyter-env.ts
@@ -60,7 +60,15 @@ export class JupyterEnvironment {
     private jupyterTimoutListener: Debouncer<unknown[], unknown> = debounce(this.onJupyterTimeout.bind(this), this.jupyterTimeoutMs, true);
     private jupyerTimedOut: boolean = false;
 
-    constructor(private readonly path: string, private printDebug: boolean, private pythonExecutable: string, private jupyterTimeoutMs: number, private type: JupyterEnvironmentType, private customConfigFolderPath: string|null) { }
+    constructor(
+        private readonly path: string,
+        private printDebug: boolean,
+        private pythonExecutable: string,
+        private jupyterTimeoutMs: number,
+        private type: JupyterEnvironmentType,
+        private customConfigFolderPath: string|null,
+        private useSimpleMode: boolean
+    ) { }
 
     public on(event: JupyterEnvironmentEvent, callback: (env: JupyterEnvironment) => void) {
         this.events.on(event, callback);
@@ -181,6 +189,14 @@ export class JupyterEnvironment {
         return this.customConfigFolderPath;
     }
 
+    public setUseSimpleMode(value: boolean) {
+        this.useSimpleMode = value;
+    }
+
+    public getUseSimpleMode(): boolean {
+        return this.useSimpleMode;
+    }
+
     public getJupyterTimeoutMs(): number {
         return this.jupyterTimeoutMs;
     }
@@ -214,14 +230,25 @@ export class JupyterEnvironment {
     }
 
     /**
-     * @param file The path of the file relative to the Jupyter environment's working directy.
+     * @param file The path of the file relative to the Jupyter environment's working directory.
      */
     public getFileUrl(file: string): string|null {
         if (!this.isRunning()) {
             return null;
         }
 
-        return `http://localhost:${this.jupyterPort}/${this.runningType === JupyterEnvironmentType.NOTEBOOK ? "notebooks" : "lab/tree"}/${file}?token=${this.jupyterToken}`;
+        return "http://localhost:" + this.jupyterPort + "/"
+            + (
+                this.runningType === JupyterEnvironmentType.NOTEBOOK
+                ? "notebooks"
+                : (
+                    this.useSimpleMode
+                    ? "doc/tree"
+                    : "lab/tree"
+                )
+            ) + "/"
+            + file
+            + "?token=" + this.jupyterToken;
     }
 
     public exit() {

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -52,6 +52,23 @@ export default class JupyterNotebookPlugin extends Plugin {
 		if (this.startEnvOnceInitialized) {
 			this.toggleJupyter();
 		}
+
+		/*
+		 * The icon used is derived from `coreui`'s Jupyter SVG Vector icon :
+		 * https://www.svgrepo.com/svg/341956/jupyter
+		 * 
+		 * It was adjusted to be a custom icon in Obsidian :
+		 * - Removed the surrounding SVG tags
+		 * - Resized to fit a viewBox of "0 0 100 100"
+		 * - Added the fill="currentColor" property to adapt to Obsidian's theme
+		 * For more information about those modifications, see Obsidian's documentation :
+		 * https://docs.obsidian.md/Plugins/User+interface/Icons#Add+your+own+icon
+		 * 
+		 * Provided under the terms of the GPL license :
+		 * https://www.svgrepo.com/page/licensing/#GPL
+		 */
+		addIcon("jupyter-logo", `<path fill="currentColor" d="m 51.4537,74.98344 c -15.406714,0 -29.180954,-5.68784 -36.479994,-13.79248 2.83328,7.29904 7.71248,13.79248 14.187674,18.24 6.493446,4.46576 14.187686,6.8856 22.29232,6.8856 8.10464,0 15.82016,-2.41984 22.29232,-6.8856 C 80.239467,74.98344 85.100427,68.49 87.933707,61.19096 80.634667,69.29864 66.86042,74.98344 51.4537,74.98344 Z m 0,-53.5192 c 15.40672,0 29.180967,5.68784 36.480007,13.79248 -2.83328,-7.29904 -7.69424,-13.79248 -14.187687,-18.24 -6.8856,-4.86096 -14.57984,-7.29904 -22.29232,-7.29904 -8.107674,0 -15.798874,2.44112 -22.29232,6.8856 C 22.689226,21.46424 17.806986,27.54424 14.973706,35.25672 22.272746,26.7356 35.654826,21.46424 51.4537,21.46424 Z M 79.829067,2.02344 c -7.566567,0 -7.566567,11.33312 0,11.33312 7.56656,0 7.56656,-11.33312 0,-11.33312 z M 22.689226,83.89672 c -4.04016,0 -7.299046,3.25888 -7.299046,7.29904 0,4.02192 3.258886,7.2808 7.299046,7.2808 4.021914,0 7.280794,-3.25888 7.280794,-7.2808 0,-4.04016 -3.258874,-7.29904 -7.280794,-7.29904 z m -6.08,-72.96 c -5.414243,0 -5.414243,8.10768 0,8.10768 5.399034,0 5.399034,-8.10768 0,-8.10768 z" id="path1" style="stroke-width:3.04" />`);
+
 		if (this.settings.displayServerRibbonIcon) {
 			this.serverRibbonIcon = this.addRibbonIcon("monitor-play", "Start Jupyter Server", this.toggleJupyter.bind(this));
 		}
@@ -72,22 +89,6 @@ export default class JupyterNotebookPlugin extends Plugin {
 		this.registerView("jupyter-view", (leaf) => new EmbeddedJupyterView(leaf, this));
 		this.registerExtensions(["ipynb"], "jupyter-view");
 		this.addSettingTab(new JupyterSettingsTab(this.app, this));
-
-		/*
-		 * The icon used is derived from `coreui`'s Jupyter SVG Vector icon :
-		 * https://www.svgrepo.com/svg/341956/jupyter
-		 * 
-		 * It was adjusted to be a custom icon in Obsidian :
-		 * - Removed the surrounding SVG tags
-		 * - Resized to fit a viewBox of "0 0 100 100"
-		 * - Added the fill="currentColor" property to adapt to Obsidian's theme
-		 * For more information about those modifications, see Obsidian's documentation :
-		 * https://docs.obsidian.md/Plugins/User+interface/Icons#Add+your+own+icon
-		 * 
-		 * Provided under the terms of the GPL license :
-		 * https://www.svgrepo.com/page/licensing/#GPL
-		 */
-		addIcon("jupyter-logo", `<path fill="currentColor" d="m 51.4537,74.98344 c -15.406714,0 -29.180954,-5.68784 -36.479994,-13.79248 2.83328,7.29904 7.71248,13.79248 14.187674,18.24 6.493446,4.46576 14.187686,6.8856 22.29232,6.8856 8.10464,0 15.82016,-2.41984 22.29232,-6.8856 C 80.239467,74.98344 85.100427,68.49 87.933707,61.19096 80.634667,69.29864 66.86042,74.98344 51.4537,74.98344 Z m 0,-53.5192 c 15.40672,0 29.180967,5.68784 36.480007,13.79248 -2.83328,-7.29904 -7.69424,-13.79248 -14.187687,-18.24 -6.8856,-4.86096 -14.57984,-7.29904 -22.29232,-7.29904 -8.107674,0 -15.798874,2.44112 -22.29232,6.8856 C 22.689226,21.46424 17.806986,27.54424 14.973706,35.25672 22.272746,26.7356 35.654826,21.46424 51.4537,21.46424 Z M 79.829067,2.02344 c -7.566567,0 -7.566567,11.33312 0,11.33312 7.56656,0 7.56656,-11.33312 0,-11.33312 z M 22.689226,83.89672 c -4.04016,0 -7.299046,3.25888 -7.299046,7.29904 0,4.02192 3.258886,7.2808 7.299046,7.2808 4.021914,0 7.280794,-3.25888 7.280794,-7.2808 0,-4.04016 -3.258874,-7.29904 -7.280794,-7.29904 z m -6.08,-72.96 c -5.414243,0 -5.414243,8.10768 0,8.10768 5.399034,0 5.399034,-8.10768 0,-8.10768 z" id="path1" style="stroke-width:3.04" />`);
 
 		// Try to unload when Obsidian is closed by the user/the OS
 		this.app.workspace.on('quit', async (_tasks: Tasks) => {

--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -25,7 +25,8 @@ export default class JupyterNotebookPlugin extends Plugin {
 		DEFAULT_SETTINGS.pythonExecutable === PythonExecutableType.PYTHON ? "python" : DEFAULT_SETTINGS.pythonExecutablePath,
 		DEFAULT_SETTINGS.jupyterTimeoutMs,
 		DEFAULT_SETTINGS.jupyterEnvType,
-		null
+		null,
+		DEFAULT_SETTINGS.useSimpleMode
 	);
 	private envProperlyInitialized = false;
 	private startEnvOnceInitialized = false;
@@ -228,6 +229,12 @@ export default class JupyterNotebookPlugin extends Plugin {
 		this.settings.jupyterEnvType = value;
 		await this.saveSettings();
 		this.env.setType(value);
+	}
+
+	public async setUseSimpleMode(value: boolean) {
+		this.settings.useSimpleMode = value;
+		await this.saveSettings();
+		this.env.setUseSimpleMode(value);
 	}
 
 	public async setDeleteCheckpoints(value: boolean) {

--- a/src/jupyter-settings.ts
+++ b/src/jupyter-settings.ts
@@ -21,6 +21,7 @@ export interface JupyterSettings {
     pythonExecutablePath: string;
     startJupyterAuto: boolean;
     jupyterEnvType: JupyterEnvironmentType;
+    useSimpleMode: boolean;
     deleteCheckpoints: boolean;
     moveCheckpointsToTrash: boolean;
     /**
@@ -45,6 +46,7 @@ export const DEFAULT_SETTINGS: JupyterSettings = {
     pythonExecutablePath: "",
     startJupyterAuto: true,
     jupyterEnvType: JupyterEnvironmentType.LAB,
+    useSimpleMode: true,
     deleteCheckpoints: false,
     moveCheckpointsToTrash: true,
     checkpointsFolder: "",
@@ -149,6 +151,16 @@ export class JupyterSettingsTab extends PluginSettingTab {
                             new JupyterRestartModal(this.plugin, "Jupyter environment type").open();
                         }
                     }).bind(this));
+            }).bind(this));
+        new Setting(this.containerEl)
+            .setName("Simple interface")
+            .setDesc("Whether to use Jupyter's Simple Interface mode when opening a notebook.")
+            .addToggle(((toggle: ToggleComponent) => {
+                toggle
+                    .setValue(this.plugin.settings.useSimpleMode)
+                    .onChange((async (value: boolean) => {
+                        await this.plugin.setUseSimpleMode(value);
+                    }).bind(this))
             }).bind(this));
         new Setting(this.containerEl)
             .setName("Delete Jupyter checkpoints")


### PR DESCRIPTION
## Change Log

### Features

- New setting `Simple interface` to open notebooks in Simple Interface mode by default when using Jupyter Lab. Default value is `true`, which is kind of a **breaking change**, in the sense that it requires user action (disabling the toggle) to have the same behavior as before (see #89)

### Fixes

- The *New icon* ribbon button will now appear at startup (see #87)