### PR TITLE
fix: adapt to new BRAT behavior

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "jupyter",
 	"name": "Jupyter",
-	"version": "0.6.0-beta",
+	"version": "0.6.1-beta",
 	"minAppVersion": "0.15.0",
 	"description": "Open .ipynb files with Jupyter in Obsidian.",
 	"author": "Maël Imhof",


### PR DESCRIPTION
The [BRAT](https://tfthacker.com/BRAT) plugin changed how it retrieves releases from plugin repositories. Having a `manifest-beta.json` file in the assets of a release is not supported anymore.

I already pushed a fix on `dev` accidentally, now the last touch should be to create a new release with the corrected GitHub workflow and everything should be working again (hopefully, as always).