### PR TITLE
fix: avoid unnecessary writes to data.json

### DIFF
--- a/src/jupyter-obsidian.ts
+++ b/src/jupyter-obsidian.ts
@@ -100,7 +100,6 @@ export default class JupyterNotebookPlugin extends Plugin {
 	}
 
 	async onunload() {
-		await this.saveSettings();
 		// Kill the Jupyter Notebook process
 		this.env.exit();
 		await this.purgeJupyterCheckpoints();


### PR DESCRIPTION
No need to write to `data.json` when Obsidian is closed, because we already write each change in the settings immediately when it happens.

Fixes #111.