### PR TITLE
fix: change main to release

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -2,7 +2,7 @@ name: Vitest (Unit Tests)
 
 on:
   pull_request:
-    branches: ["main", "dev"]
+    branches: ["release", "dev"]
 
 jobs:
   test:

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: ["release", "dev"]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Last-minute fixes for the auto-testing GitHub Actions workflow.

- Replaced `main` with `release` because I forgot to change it in the template I used.
- Added explicit permissions to the workflow because GitHub recommended it to me.