### PR TITLE
fix: add explicit permissions to safeguard workflow

### DIFF
--- a/.github/workflows/release-pr-safeguard.yaml
+++ b/.github/workflows/release-pr-safeguard.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - release
 
+permissions: {}
+
 jobs:
   restrict-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Noticed a small missing part in this workflow, decided to add it to get rid of the GraphQL warning.