### PR TITLE
fix: close editor tab when file gets deleted

### DIFF
--- a/src/features/open-notebooks/open-notebooks-feature.ts
+++ b/src/features/open-notebooks/open-notebooks-feature.ts
@@ -9,8 +9,8 @@ import {
 } from '@/services/jupyter-environment';
 import { Settings, SettingsProxy } from '@/settings';
 import { registerOpenNotebookSettingsUI } from './open-notebooks-settings';
-import { Notice, setIcon, setTooltip } from 'obsidian';
-import { EmbeddedJupyterView } from '@/services/jupyter-view';
+import { Notice, setIcon, setTooltip, TAbstractFile, TFile } from 'obsidian';
+import { EmbeddedJupyterView, getJupyterViews, JUPYTER_VIEW_TYPE } from '@/services/jupyter-view';
 import { displayJupyterErrorModal } from './jupyter-error-modals';
 
 /**
@@ -56,12 +56,47 @@ export class OpenNotebooksFeature implements IFeature {
 
 		// Let Obsidian know how to display Jupyter files
 		this.plugin.registerView(
-			'jupyter-view',
+			JUPYTER_VIEW_TYPE,
 			(leaf) => new EmbeddedJupyterView(leaf, this.plugin)
 		);
 
 		// Let Obsidian know which file extensions are Jupyter notebooks
-		this.plugin.registerExtensions(['ipynb'], 'jupyter-view');
+		this.plugin.registerExtensions(['ipynb'], JUPYTER_VIEW_TYPE);
+
+		// When a notebook file is deleted, close any views that have it open
+		this.plugin.registerEvent(
+			this.plugin.app.vault.on(
+				'delete',
+				(async (file: TAbstractFile) => {
+					// We only care about TFile instances
+					if (!(file instanceof TFile)) {
+						return;
+					}
+
+					// We only care about .ipynb files
+					if (!file.path.endsWith('.ipynb')) {
+						return;
+					}
+
+					// Close Jupyter views where this file is opened
+					const jupyterViews = getJupyterViews(this.plugin.app.workspace);
+					for (const jupyterView of jupyterViews) {
+						if (
+							jupyterView.file?.path === file.path ||
+							// Not sure why, but sometimes a file in the root directory will have a path that
+							// does not start with '/', thus the match won't be made and the view won't be closed,
+							// unless I manually add this condition below.
+							(file.parent === null && jupyterView.file?.path === '/' + file.name)
+						) {
+							await jupyterView.leaf.setViewState({
+								type: JUPYTER_VIEW_TYPE,
+								state: { file: null }
+							});
+						}
+					}
+				}).bind(this)
+			)
+		);
 	}
 
 	/**

--- a/src/services/jupyter-view.ts
+++ b/src/services/jupyter-view.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, FileView, TFile, WorkspaceLeaf } from 'obsidian';
+import { ButtonComponent, FileView, TFile, Workspace, WorkspaceLeaf } from 'obsidian';
 import JupyterForObsidian from '@/jupyter-for-obsidian';
 import {
 	JupyterEnvironment,
@@ -8,6 +8,13 @@ import {
 import { JupyterModalButton } from '@/services/jupyter-modal';
 
 export const JUPYTER_VIEW_TYPE = 'jupyter-view';
+
+/** Helper function to get active leaves of type EmbeddedJupyterView in the workspace. */
+export function getJupyterViews(workspace: Workspace): EmbeddedJupyterView[] {
+	return workspace
+		.getLeavesOfType(JUPYTER_VIEW_TYPE)
+		.flatMap((l) => (l.view instanceof EmbeddedJupyterView ? [l.view] : []));
+}
 
 /**
  * Core view for Jupyter documents. Handles situations where the Jupyter
@@ -191,6 +198,9 @@ export class EmbeddedJupyterView extends FileView {
 	}
 
 	protected async onClose() {
+		// Let the superclass clean up first
+		await super.onClose();
+
 		this.openedFile = null;
 		this.messageContainerEl = null;
 		this.messageHeaderEl = null;


### PR DESCRIPTION
Previously, when an `.ipynb` file was opened in an editor tab and then deleted through the Obsidian's file tree, the editor tab remained open, unaware of the deletion.

This PR introduces a new behavior where the tab is closed as soon as the file is deleted. There is no point in forcing a save, since the file was deleted.

Fixes #114.