### PR TITLE
chore: bump plugin version

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "jupyter",
 	"name": "Jupyter",
-	"version": "7.0.0-beta",
+	"version": "0.7.0-beta",
 	"minAppVersion": "0.15.0",
 	"description": "Open .ipynb files with Jupyter in Obsidian.",
 	"author": "Maël Imhof",


### PR DESCRIPTION
Correct the versions I bumped to, we are still far from `7.0.0`.