### PR TITLE
Beta release `0.7.0-beta`

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
 	"id": "jupyter",
 	"name": "Jupyter",
-	"version": "7.0.0-beta",
+	"version": "0.7.0-beta",
 	"minAppVersion": "0.15.0",
 	"description": "Open .ipynb files with Jupyter in Obsidian.",
 	"author": "Maël Imhof",


### PR DESCRIPTION
See the corresponding release for the full list of changes, see also #146.

## Change Log

### Features

- Embeds are now implemented. You can embed your Jupyter notebooks in markdown notes, hover over links in the file explorer or inside other notes and get a glimpse at what is in the file (see #143)
- Added support for `python3` in the settings (see #135)

### Fixes

- Moving a Jupyter notebook to a new window should not crash Obsidian anymore (see #144)
- When a notebook file gets deleted, tabs where it was opened are automatically closed (#136)
- The `What Changed` title of the release modal is now displayed on top of release notes, not below them (see #137)

### Documentation

- Added end-user documentation for the embeds feature and the associated settings (see #143)
- Added technical documentation for how embeds were implemented, to help me in the future rework the code and possibly to help others better understand how embeds work too (see #143)
- Improved error reporting, messages, and troubleshooting guides. Fixed links to the documentation in error messages (see #135)

### Logistic

- Removed e2e tests, I wasn't able to make them reliable enough (see #139)
- Added MIT `LICENSE` (see #139)
- Automate broken links detection through GitHub CI (see #140)